### PR TITLE
feat: make about us link to team

### DIFF
--- a/src/components/ui/Footer.astro
+++ b/src/components/ui/Footer.astro
@@ -20,8 +20,7 @@ const logos = [
 ];
 
 const links = [
-  { name: "About us", href: "/about" },
-  { name: "Team", href: "/#team" },
+  { name: "About us", href: "/#team" },
   { name: "Services", href: "/#services" },
   { name: "Blog", href: "/articles" },
 ];

--- a/src/components/ui/Navbar.astro
+++ b/src/components/ui/Navbar.astro
@@ -25,7 +25,7 @@ const allIndustries: CollectionEntry<"industries">[] = (
 );
 
 const menuitems = [
-  { href: "/about", label: "About us", dropdown: false, dropdownContent: [] },
+  { href: "#team", label: "About us", dropdown: false, dropdownContent: [] },
   {
     href: "/services",
     label: "Services",

--- a/src/components/ui/Navbar.astro
+++ b/src/components/ui/Navbar.astro
@@ -25,7 +25,7 @@ const allIndustries: CollectionEntry<"industries">[] = (
 );
 
 const menuitems = [
-  { href: "#team", label: "About us", dropdown: false, dropdownContent: [] },
+  { href: "/#team", label: "About us", dropdown: false, dropdownContent: [] },
   {
     href: "/services",
     label: "Services",


### PR DESCRIPTION
As per the discussion this morning

This pull request updates navigation links in the `Footer` and `Navbar` components to ensure consistency and correct routing. The changes primarily involve modifying the `About us` link to point to the `#team` section instead of a separate page.

### Updates to navigation links:

* [`src/components/ui/Footer.astro`](diffhunk://#diff-fb7b536137d6087d9ad4712e1da879cbb8c837fc23acbe13e64d657dd0bbd5e0L23-R23): Updated the `About us` link in the footer to point to the `#team` section instead of the `/about` page.
* [`src/components/ui/Navbar.astro`](diffhunk://#diff-901342aaa946d15336c84272609205560fba53a0c96c809e65c83b5f26204ce2L28-R28): Updated the `About us` link in the navbar to point to `#team` for consistency with the footer.